### PR TITLE
Fix composer plugin api requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"php": ">=5.4.0",
 		"illuminate/support": "~4.2|~5.0",
-		"composer-plugin-api": "1.0.*"
+		"composer-plugin-api": "^1.0.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Without this patch if we bump the composer plugin API to 1.1+ your plugin won't be installable anymore.
